### PR TITLE
Fix button shifting due to screen transition animations

### DIFF
--- a/src/client/ui_menubutton.cpp
+++ b/src/client/ui_menubutton.cpp
@@ -68,6 +68,28 @@ void UI_MenuButton::UpdateBounds()
 
 	if (!_updatingFromLerp)
 	{
+		// -- HACKY HACK --
+		// Whenever we start an animation, we set this to nonzero. We do NOT want to run this check if we have not animated (are at 0,0).
+		if (_interpTimeSeconds != 0) {
+			_interpTimeSeconds = 0.f; // Reset the time so we don't animate again
+
+			// Position of the button before it moved
+			const float eval = Maths::Pow(Maths::Sin(_posInterpAlpha * (Maths::PI_F / 2.f)), 1.f / 2.f);
+			const Vector2 evalPos = _fromPos + ((_targetPos - _fromPos) * eval);
+
+			// We use evalPos to check the calculated initial position of the button. 
+			// If the current root position is not evalPos, we have moved and thus need to compensate for what our animation did and go back.
+			if (_rootPos != evalPos) {
+				const Vector2 delta = _rootPos - evalPos;
+
+				_updatingFromLerp = true;
+				SetX(UICoord(GetBounds().x.relative, GetBounds().x.absolute + delta.x));
+				SetY(UICoord(GetBounds().y.relative, GetBounds().y.absolute + delta.y));
+				_updatingFromLerp = false;
+			}
+		}
+		// -- END HACK --
+
 		_rootPos = Vector2(this->GetBounds().x.absolute, this->GetBounds().y.absolute);
 	}
 }

--- a/src/client/ui_menubutton.cpp
+++ b/src/client/ui_menubutton.cpp
@@ -68,6 +68,30 @@ void UI_MenuButton::UpdateBounds()
 
 	if (!_updatingFromLerp)
 	{
+		// -- HACKY HACK --
+		// Whenever we start an animation, we set this to nonzero. We do NOT want to run this check if we have not animated (are at 0,0).
+		if (_interpTimeSeconds != 0) 
+		{
+			_interpTimeSeconds = 0.f; // Reset the time so we don't animate again
+
+			// Position of the button before it moved
+			const float eval = Maths::Pow(Maths::Sin(_posInterpAlpha * (Maths::PI_F / 2.f)), 1.f / 2.f);
+			const Vector2 evalPos = _fromPos + ((_targetPos - _fromPos) * eval);
+
+			// We use evalPos to check the calculated initial position of the button. 
+			// If the current root position is not evalPos, we have moved and thus need to compensate for what our animation did and go back.
+			if (_rootPos != evalPos) 
+			{
+				const Vector2 delta = _rootPos - evalPos;
+
+				_updatingFromLerp = true;
+				SetX(UICoord(GetBounds().x.relative, GetBounds().x.absolute + delta.x));
+				SetY(UICoord(GetBounds().y.relative, GetBounds().y.absolute + delta.y));
+				_updatingFromLerp = false;
+			}
+		}
+		// -- END HACK --
+
 		_rootPos = Vector2(this->GetBounds().x.absolute, this->GetBounds().y.absolute);
 	}
 }


### PR DESCRIPTION
Implement a solution to prevent buttons from shifting during screen transitions by maintaining the expected root position and adjusting for any animation-induced changes.